### PR TITLE
Add CI job for coverage badges and update Helm chart publishing path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,26 +79,54 @@ jobs:
         run: |
           cd deployment/k8s && make helm-unittest
 
-  # deploy-docs:
-  #   needs: tests
-  #   runs-on: ubuntu-latest
-  #   if: github.ref == 'refs/heads/main'
+  deploy-docs:
+    needs: tests
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Setup Python
-  #       uses: ./.github/actions/setup-python
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
 
-  #     - name: Download Coverage Report
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: coverage
-  #         path: coverage_report
+      - name: Download Coverage Report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: coverage_report
 
-  #     - name: Generate Badges
-  #       run: |
-  #         make gen-coverage-badge
-  #         make gen-tests-count-badge
+      - name: Generate Badges
+        run: |
+          make gen-coverage-badge
+          make gen-test-count-badge
 
-  #     - name: Deploy docs
-  #       run: make deploy-docs
+      - name: Deploy badges to GitHub Pages
+        run: |
+          git clone --depth 1 --branch gh-pages --single-branch https://github.com/${{ github.repository }} /tmp/gh-pages || \
+          (echo "gh-pages branch not found, creating it." && \
+            mkdir -p /tmp/gh-pages && \
+            cd /tmp/gh-pages && \
+            git init && \
+            git remote add origin https://github.com/${{ github.repository }} && \
+            git checkout -b gh-pages && \
+            # Create a minimal index.html for the root if it doesn't exist
+            echo "<html><head><title>LangGate AI Gateway</title></head><body><h1>LangGate AI Gateway</h1><p>See <a href='coverage/'>coverage reports</a>.</p><p>Helm charts are available in the <a href='charts/'>charts directory</a>.</p></body></html>" > index.html && \
+            git add index.html && \
+            git commit -m "Initial commit for gh-pages with index.html")
+
+          cd /tmp/gh-pages
+          mkdir -p coverage
+          cp -a ${{ github.workspace }}/coverage_report/* coverage/
+
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+          git add coverage/*
+          if git diff --staged --quiet; then
+            echo "No changes to commit to gh-pages coverage."
+          else
+            git commit -m "Update coverage badges and report [skip ci]"
+            git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
+          fi

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:
+          config: deployment/k8s/charts/.cr.yaml
           charts_dir: deployment/k8s/charts
           skip_existing: false
         env:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # LangGate AI Gateway
 <p align="left">
   <a href="https://pypi.org/project/langgate" target="_blank"><img src="https://img.shields.io/pypi/pyversions/langgate.svg" alt="Python versions"></a> <a href="https://pypi.org/project/langgate" target="_blank"><img src="https://img.shields.io/pypi/v/langgate" alt="PyPI"></a> <a href="https://github.com/Tanantor/langgate/actions?query=workflow%3A%22CI+Checks%22" target="_blank"><img src="https://github.com/Tanantor/langgate/actions/workflows/ci.yaml/badge.svg?event=push&branch=main" alt="CI Checks"></a>
-  <!-- These badges will be enabled when GitHub Pages is available -->
-  <!--
-  <a href="https://github.com/Tanantor/langgate/tree/main/tests" target="_blank"><img src="https://tanantor.github.io/langgate/coverage/test-count-badge.svg" alt="Tests"></a> <a href="https://github.com/Tanantor/langgate/actions?query=workflow%3ACI" target="_blank"><img src="https://tanantor.github.io/langgate/coverage/coverage-badge.svg" alt="Coverage"></a>
-  -->
+  <a href="https://github.com/Tanantor/langgate/tree/main/tests" target="_blank"><img src="https://img.shields.io/badge/dynamic/xml?url=https://tanantor.github.io/langgate/coverage/test-count.xml&query=//testcount&label=tests&color=blue&style=flat" alt="Tests"></a> <a href="https://github.com/Tanantor/langgate/actions?query=workflow%3ACI" target="_blank"><img src="https://tanantor.github.io/langgate/coverage/coverage-badge.svg" alt="Coverage"></a>
 </p>
 
 LangGate is a lightweight, high-performance gateway for AI model inference.

--- a/deployment/k8s/charts/.cr.yaml
+++ b/deployment/k8s/charts/.cr.yaml
@@ -1,0 +1,4 @@
+owner: Tanantor
+git-repo: langgate
+pages-branch: gh-pages
+pages-index-path: charts/index.yaml


### PR DESCRIPTION
- Add a CI workflow job to generate and deploy coverage badges to GitHub Pages.
- Add `.cr.yaml` to configure chart-releaser to update Helm chart index path, reflecting the new gh-pages structure. 
- Update the README to include dynamic badges for test counts and coverage.