### PR TITLE
Load environment variables in local transformer client

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+<!-- What does this pull request accomplish? -->
+
+## Related Pull Requests
+<!-- Provide links to any related pull requests. -->
+
+## Relevant Issues
+<!-- Does this pull request address any open issues? List them with [closing keywords](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->
+
+## Additional Details
+<!-- Add any additional context, screenshots or attachments relevant to the pull request here. -->
+
+## Type of Changes
+<!-- Select the category or categories that best describe(s) the nature of changes made in this pull request. -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to cease working as expected)
+
+## Checklist
+<!-- Use this checklist to ensure that all necessary changes have been made before submitting the pull request. -->
+- [ ] Documentation updated
+- [ ] Docstrings/comments added
+- [ ] Unit/Integration tests added
+- [ ] Pytest warnings checked in CI logs

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gcp_sa*.json
 !README.md
 !CONTRIBUTING.md
 !CHANGELOG.md
+!pull_request_template.md
 .vscode
 # terraform
 **/.terraform*

--- a/packages/transform/src/langgate/transform/local.py
+++ b/packages/transform/src/langgate/transform/local.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from dotenv import load_dotenv
 from pydantic import SecretStr
 
 from langgate.core.logging import get_logger
@@ -92,6 +93,11 @@ class LocalTransformerClient(TransformerClientProtocol):
             self._process_model_mappings(config.models)
         else:
             self._set_empty_config()
+
+        # Load environment variables from .env file if it exists
+        if self.env_file_path.exists():
+            load_dotenv(self.env_file_path)
+            logger.debug("loaded_transformer_env_file", path=str(self.env_file_path))
 
     def _set_empty_config(self) -> None:
         """Set empty/default config state, typically used in error scenarios."""


### PR DESCRIPTION
## Description
<!-- What does this pull request accomplish? -->
- Load environment variables from .env file in `LocalTransformerClient` initialisation.
- This is needed if the local registry and transformer clients are running in separate processes.

## Related Pull Requests
<!-- Provide links to any related pull requests. -->

## Relevant Issues
<!-- Does this pull request address any open issues? List them with [closing keywords](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->

## Additional Details
<!-- Add any additional context, screenshots or attachments relevant to the pull request here. -->

## Type of Changes
<!-- Select the category or categories that best describe(s) the nature of changes made in this pull request. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to cease working as expected)

## Checklist
<!-- Use this checklist to ensure that all necessary changes have been made before submitting the pull request. -->
- [ ] Documentation updated
- [x] Docstrings/comments added
- [ ] Unit/Integration tests added
- [ ] Pytest warnings checked in CI logs
