### PR TITLE
Include service provider API format when returning transformed params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ gcp_sa*.json
 !CONTRIBUTING.md
 !CHANGELOG.md
 !pull_request_template.md
-!SPIKE_*.md
+!SPIKE*.md
 .vscode
 # terraform
 **/.terraform*

--- a/README.md
+++ b/README.md
@@ -204,11 +204,17 @@ class ModelFactory:
         # Transform parameters using the transformer client
         # If switching to using the proxy, you would remove this line
         # and let the proxy handle the parameter transformation instead.
-        model_params = await self.langgate_client.get_params(model_id, params)
+        api_format, model_params = await self.langgate_client.get_params(
+            model_id, params
+        )
+        # api_format defaults to the provider id unless specified in the config.
+        # e.g. Specify "openai" for OpenAI-compatible APIs, etc.
+        print("API format:", api_format)
         pp(model_params)
 
         # Get the appropriate model class based on provider
-        model_class = MODEL_CLASS_MAP.get(model_info.provider.id)
+        client_cls_key = ModelProviderId(api_format)
+        model_class = MODEL_CLASS_MAP.get(client_cls_key)
         if not model_class:
             raise ValueError(f"No model class for provider {model_info.provider.id}")
 
@@ -226,7 +232,8 @@ model_id = "openai/gpt-4o"
 model = await model_factory.create_model(model_id, {"temperature": 0.7})
 model
 ```
-```py
+```text
+API format: openai
 {'api_key': SecretStr('**********'),
  'base_url': 'https://api.openai.com/v1',
  'model': 'gpt-4o',

--- a/examples/combined_example.ipynb
+++ b/examples/combined_example.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,9 +33,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_langgate_local_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_model_registry_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_model_data             \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m62\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_model_registry_singleton\u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36menv_file_exists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36menv_file_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_registry_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_config_path          \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_env_file_path        \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_transformer_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:16:18\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_langgate_local_client_singleton\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "from langgate.sdk import LangGateLocal\n",
     "\n",
@@ -53,19 +72,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Available models: 59\n",
+      "\u001b[2m2025-06-17 23:17:02\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:17:02\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
+      "Available models: 5\n",
       "- openai/gpt-4.1: GPT-4.1\n",
-      "- openai/gpt-4.1-mini: GPT-4.1 mini\n",
-      "- openai/gpt-4.1-nano: GPT-4.1 nano\n",
-      "- openai/gpt-4o: GPT-4o\n",
-      "- openai/gpt-4o-mini: GPT-4o mini\n"
+      "- openai/o3: o3\n",
+      "- openai/o3-high: o3-high\n",
+      "- anthropic/claude-sonnet-4: Claude-4 Sonnet\n",
+      "- anthropic/claude-sonnet-4-reasoning: Claude-4 Sonnet R\n"
      ]
     }
    ],
@@ -86,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -121,12 +142,13 @@
       "Description: GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\n",
       "\n",
       "Transformed parameters:\n",
-      "{'api_key': SecretStr('**********'),\n",
-      " 'base_url': 'https://api.openai.com/v1',\n",
-      " 'max_tokens': 1000,\n",
-      " 'model': 'gpt-4.1',\n",
-      " 'stream': True,\n",
-      " 'temperature': 0.7}\n"
+      "('openai',\n",
+      " {'api_key': SecretStr('**********'),\n",
+      "  'base_url': 'https://api.openai.com/v1',\n",
+      "  'max_tokens': 1000,\n",
+      "  'model': 'gpt-4.1',\n",
+      "  'stream': True,\n",
+      "  'temperature': 0.7})\n"
      ]
     }
    ],
@@ -158,24 +180,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model: Claude-4 Sonnet R High\n",
+      "Model: Claude-4 Sonnet R\n",
       "Provider: Anthropic\n",
-      "Description: Claude 4 Sonnet with standard reasoning capabilities optimized for complex problem-solving.\n",
+      "Description: Claude-4 Sonnet with reasoning capabilities.\n",
       "\n",
       "Transformed parameters:\n",
-      "{'api_key': SecretStr('**********'),\n",
-      " 'base_url': 'https://api.anthropic.com',\n",
-      " 'max_tokens': 64000,\n",
-      " 'model': 'claude-sonnet-4',\n",
-      " 'stream': True,\n",
-      " 'thinking': {'budget_tokens': 1024, 'type': 'enabled'}}\n"
+      "('anthropic',\n",
+      " {'api_key': SecretStr('**********'),\n",
+      "  'base_url': 'https://api.anthropic.com',\n",
+      "  'max_tokens': 1000,\n",
+      "  'model': 'claude-sonnet-4-0',\n",
+      "  'stream': True,\n",
+      "  'thinking': {'budget_tokens': 1024, 'type': 'enabled'}})\n"
      ]
     }
    ],
@@ -206,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -223,25 +246,27 @@
       " 'supports_vision': True}\n",
       "\n",
       "Transformed parameters with tools:\n",
-      "{'api_key': SecretStr('**********'),\n",
-      " 'base_url': 'https://api.openai.com/v1',\n",
-      " 'max_tokens': 1000,\n",
-      " 'model': 'gpt-4.1',\n",
-      " 'stream': True,\n",
-      " 'temperature': 0.7,\n",
-      " 'tools': [{'function': {'description': 'Get the current weather in a location',\n",
-      "                         'name': 'get_weather',\n",
-      "                         'parameters': {'properties': {'location': {'description': 'The '\n",
-      "                                                                                   'city '\n",
-      "                                                                                   'and '\n",
-      "                                                                                   'country, '\n",
-      "                                                                                   'e.g., '\n",
-      "                                                                                   'Cork, '\n",
-      "                                                                                   'Ireland',\n",
-      "                                                                    'type': 'string'}},\n",
-      "                                        'required': ['location'],\n",
-      "                                        'type': 'object'}},\n",
-      "            'type': 'function'}]}\n"
+      "('openai',\n",
+      " {'api_key': SecretStr('**********'),\n",
+      "  'base_url': 'https://api.openai.com/v1',\n",
+      "  'max_tokens': 1000,\n",
+      "  'model': 'gpt-4.1',\n",
+      "  'stream': True,\n",
+      "  'temperature': 0.7,\n",
+      "  'tools': [{'function': {'description': 'Get the current weather in a '\n",
+      "                                         'location',\n",
+      "                          'name': 'get_weather',\n",
+      "                          'parameters': {'properties': {'location': {'description': 'The '\n",
+      "                                                                                    'city '\n",
+      "                                                                                    'and '\n",
+      "                                                                                    'country, '\n",
+      "                                                                                    'e.g., '\n",
+      "                                                                                    'Cork, '\n",
+      "                                                                                    'Ireland',\n",
+      "                                                                     'type': 'string'}},\n",
+      "                                         'required': ['location'],\n",
+      "                                         'type': 'object'}},\n",
+      "             'type': 'function'}]})\n"
      ]
     }
    ],

--- a/examples/custom_clients.ipynb
+++ b/examples/custom_clients.ipynb
@@ -54,14 +54,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 26, 56, 800763, tzinfo=datetime.timezone.utc))\n"
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_langgate_local_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_model_registry_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_model_data             \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m62\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_model_registry_singleton\u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36menv_file_exists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36menv_file_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_registry_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_config_path          \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_env_file_path        \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_transformer_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_langgate_local_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:18:59\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
+      "LLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 18, 59, 740302, tzinfo=datetime.timezone.utc))\n"
      ]
     }
    ],
@@ -92,14 +106,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 26, 56, 800763, tzinfo=datetime.timezone.utc))\n"
+      "LLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 18, 59, 740302, tzinfo=datetime.timezone.utc))\n"
      ]
     }
    ],
@@ -121,18 +135,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:27:24\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mreusing_registry_singleton    \u001b[0m \u001b[36minitialized\u001b[0m=\u001b[35mTrue\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:24\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:24\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:24\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
-      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 26, 56, 800763, tzinfo=datetime.timezone.utc), extra_field='', custom_metadata={})\n"
+      "\u001b[2m2025-06-17 23:19:37\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mreusing_registry_singleton    \u001b[0m \u001b[36minitialized\u001b[0m=\u001b[35mTrue\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:37\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:37\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:37\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
+      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 18, 59, 740302, tzinfo=datetime.timezone.utc), extra_field='', custom_metadata={})\n"
      ]
     }
    ],
@@ -168,18 +182,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:27:35\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mreusing_registry_singleton    \u001b[0m \u001b[36minitialized\u001b[0m=\u001b[35mTrue\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:35\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:35\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:35\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
-      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 26, 56, 800763, tzinfo=datetime.timezone.utc), extra_field='', custom_metadata={})\n"
+      "\u001b[2m2025-06-17 23:19:39\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mreusing_registry_singleton    \u001b[0m \u001b[36minitialized\u001b[0m=\u001b[35mTrue\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:39\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:39\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:39\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
+      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 18, 59, 740302, tzinfo=datetime.timezone.utc), extra_field='', custom_metadata={})\n"
      ]
     }
    ],
@@ -204,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,19 +237,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:27:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_http_registry_client_singleton\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class 'langgate.core.models.LLMInfo'>\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_http_registry_client_singleton\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:27:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m59\u001b[0m\n",
-      "LLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 25, 55, 980715, tzinfo=TzInfo(UTC)))\n"
+      "\u001b[2m2025-06-17 23:19:44\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_http_registry_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:44\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class 'langgate.core.models.LLMInfo'>\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:44\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_http_registry_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:44\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:44\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m58\u001b[0m\n",
+      "LLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 15, 17, 856172, tzinfo=TzInfo(UTC)))\n"
      ]
     }
    ],
@@ -257,17 +271,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:28:03\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class '__main__.CustomLLMInfo'>\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:28:03\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:28:03\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m59\u001b[0m\n",
-      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 25, 55, 980715, tzinfo=TzInfo(UTC)), extra_field='', custom_metadata={})\n"
+      "\u001b[2m2025-06-17 23:19:46\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class '__main__.CustomLLMInfo'>\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:46\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:46\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m58\u001b[0m\n",
+      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 15, 17, 856172, tzinfo=TzInfo(UTC)), extra_field='', custom_metadata={})\n"
      ]
     }
    ],
@@ -303,17 +317,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:28:08\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class '__main__.CustomLLMInfo'>\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:28:08\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:28:08\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m59\u001b[0m\n",
-      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider=ModelProvider(id='openai', name='OpenAI', description=None), description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), updated_dt=datetime.datetime(2025, 6, 10, 22, 25, 55, 980715, tzinfo=TzInfo(UTC)), extra_field='', custom_metadata={})\n"
+      "\u001b[2m2025-06-17 23:19:48\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class '__main__.CustomLLMInfo'>\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:48\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:19:48\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m58\u001b[0m\n",
+      "CustomLLMInfo(id='openai/gpt-4.1', name='GPT-4.1', provider_id='openai', description=\"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\", costs=ModelCost(input_cost_per_token=Decimal('0.000002'), output_cost_per_token=Decimal('0.000008'), input_cost_per_token_batches=None, output_cost_per_token_batches=None, cache_read_input_token_cost=Decimal('5E-7')), capabilities=ModelCapabilities(supports_tools=True, supports_parallel_tool_calls=True, supports_vision=True, supports_audio_input=None, supports_audio_output=None, supports_prompt_caching=True, supports_response_schema=True, supports_system_messages=True, supports_tool_choice=True), context_window=ContextWindow(max_input_tokens=1047576, max_output_tokens=32768), provider=ModelProvider(id='openai', name='OpenAI', description=None), updated_dt=datetime.datetime(2025, 6, 17, 22, 15, 17, 856172, tzinfo=TzInfo(UTC)), extra_field='', custom_metadata={})\n"
      ]
     }
    ],

--- a/examples/http_client_example.ipynb
+++ b/examples/http_client_example.ipynb
@@ -48,9 +48,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:30:26\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_http_registry_client_singleton\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:30:26\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class 'langgate.core.models.LLMInfo'>\u001b[0m\n",
-      "\u001b[2m2025-06-10 23:30:26\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_http_registry_client_singleton\u001b[0m\n"
+      "\u001b[2m2025-06-17 23:20:36\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_http_registry_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:20:36\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_http_registry_client\u001b[0m \u001b[36mapi_key\u001b[0m=\u001b[35mSecretStr('**********')\u001b[0m \u001b[36mbase_url\u001b[0m=\u001b[35mhttp://localhost:4000/api/v1\u001b[0m \u001b[36mmodel_info_cls\u001b[0m=\u001b[35m<class 'langgate.core.models.LLMInfo'>\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:20:36\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_http_registry_client_singleton\u001b[0m\n"
      ]
     }
    ],
@@ -78,9 +78,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:30:28\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:30:28\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m59\u001b[0m\n",
-      "Available models: 59\n",
+      "\u001b[2m2025-06-17 23:20:41\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:20:41\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m58\u001b[0m\n",
+      "Available models: 58\n",
       "- openai/gpt-4.1: GPT-4.1\n",
       "- openai/gpt-4.1-mini: GPT-4.1 mini\n",
       "- openai/gpt-4.1-nano: GPT-4.1 nano\n",
@@ -138,7 +138,8 @@
       " 'id': 'openai/gpt-4.1',\n",
       " 'name': 'GPT-4.1',\n",
       " 'provider': {'id': 'openai', 'name': 'OpenAI'},\n",
-      " 'updated_dt': datetime.datetime(2025, 6, 10, 22, 25, 55, 980715, tzinfo=TzInfo(UTC))}\n"
+      " 'provider_id': 'openai',\n",
+      " 'updated_dt': datetime.datetime(2025, 6, 17, 22, 15, 17, 856172, tzinfo=TzInfo(UTC))}\n"
      ]
     }
    ],

--- a/examples/langchain_examples.ipynb
+++ b/examples/langchain_examples.ipynb
@@ -51,13 +51,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_langgate_local_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_model_registry_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_model_data             \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m62\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_model_registry_singleton\u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36menv_file_exists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36menv_file_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_registry_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_config_path          \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_env_file_path        \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_transformer_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_langgate_local_client_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:21:05\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
       "{'capabilities': {'supports_assistant_prefill': True,\n",
       "                  'supports_prompt_caching': True,\n",
       "                  'supports_response_schema': True,\n",
@@ -74,7 +88,8 @@
       " 'id': 'anthropic/claude-sonnet-4-reasoning',\n",
       " 'name': 'Claude-4 Sonnet R',\n",
       " 'provider': {'id': 'anthropic', 'name': 'Anthropic'},\n",
-      " 'updated_dt': datetime.datetime(2025, 6, 10, 22, 21, 35, 199984, tzinfo=datetime.timezone.utc)}\n"
+      " 'provider_id': 'anthropic',\n",
+      " 'updated_dt': datetime.datetime(2025, 6, 17, 22, 21, 5, 789663, tzinfo=datetime.timezone.utc)}\n"
      ]
     }
    ],
@@ -108,18 +123,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'api_key': SecretStr('**********'),\n",
-      " 'base_url': 'https://api.anthropic.com',\n",
-      " 'model': 'claude-sonnet-4',\n",
-      " 'stream': True,\n",
-      " 'thinking': {'budget_tokens': 1024, 'type': 'enabled'}}\n"
+      "('anthropic',\n",
+      " {'api_key': SecretStr('**********'),\n",
+      "  'base_url': 'https://api.anthropic.com',\n",
+      "  'model': 'claude-sonnet-4-0',\n",
+      "  'stream': True,\n",
+      "  'thinking': {'budget_tokens': 1024, 'type': 'enabled'}})\n"
      ]
     }
    ],
@@ -153,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,11 +219,17 @@
     "        # Transform parameters using the transformer client\n",
     "        # If switching to using the proxy, you would remove this line\n",
     "        # and let the proxy handle the parameter transformation instead.\n",
-    "        model_params = await self.langgate_client.get_params(model_id, params)\n",
+    "        api_format, model_params = await self.langgate_client.get_params(\n",
+    "            model_id, params\n",
+    "        )\n",
+    "        # api_format defaults to the provider id unless specified in the config.\n",
+    "        # e.g. Specify \"openai\" for OpenAI-compatible APIs, etc.\n",
+    "        print(\"API format:\", api_format)\n",
     "        pp(model_params)\n",
     "\n",
     "        # Get the appropriate model class based on provider\n",
-    "        model_class = MODEL_CLASS_MAP.get(model_info.provider.id)\n",
+    "        client_cls_key = ModelProviderId(api_format)\n",
+    "        model_class = MODEL_CLASS_MAP.get(client_cls_key)\n",
     "        if not model_class:\n",
     "            raise ValueError(f\"No model class for provider {model_info.provider.id}\")\n",
     "\n",
@@ -222,13 +244,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "API format: openai\n",
       "{'api_key': SecretStr('**********'),\n",
       " 'base_url': 'https://api.openai.com/v1',\n",
       " 'model': 'gpt-4.1',\n",
@@ -239,10 +262,10 @@
     {
      "data": {
       "text/plain": [
-       "(ChatOpenAI(client=<openai.resources.chat.completions.completions.Completions object at 0x119203cb0>, async_client=<openai.resources.chat.completions.completions.AsyncCompletions object at 0x11c324830>, root_client=<openai.OpenAI object at 0x119200590>, root_async_client=<openai.AsyncOpenAI object at 0x11c324590>, model_name='gpt-4.1', temperature=0.7, model_kwargs={}, openai_api_key=SecretStr('**********'), openai_api_base='https://api.openai.com/v1', streaming=True),\n",
+       "(ChatOpenAI(client=<openai.resources.chat.completions.completions.Completions object at 0x12c9842f0>, async_client=<openai.resources.chat.completions.completions.AsyncCompletions object at 0x12c984d70>, root_client=<openai.OpenAI object at 0x12bd0cad0>, root_async_client=<openai.AsyncOpenAI object at 0x12c984ad0>, model_name='gpt-4.1', temperature=0.7, model_kwargs={}, openai_api_key=SecretStr('**********'), openai_api_base='https://api.openai.com/v1', streaming=True),\n",
        " {'id': 'openai/gpt-4.1',\n",
        "  'name': 'GPT-4.1',\n",
-       "  'provider': {'id': 'openai', 'name': 'OpenAI'},\n",
+       "  'provider_id': 'openai',\n",
        "  'description': \"GPT-4.1 is the latest iteration of OpenAI's flagship model with improved capabilities across all domains.\",\n",
        "  'costs': {'input_cost_per_token': Decimal('0.000002'),\n",
        "   'output_cost_per_token': Decimal('0.000008'),\n",
@@ -255,10 +278,11 @@
        "   'supports_system_messages': True,\n",
        "   'supports_tool_choice': True},\n",
        "  'context_window': {'max_input_tokens': 1047576, 'max_output_tokens': 32768},\n",
-       "  'updated_dt': datetime.datetime(2025, 6, 10, 22, 21, 35, 199950, tzinfo=datetime.timezone.utc)})"
+       "  'provider': {'id': 'openai', 'name': 'OpenAI'},\n",
+       "  'updated_dt': datetime.datetime(2025, 6, 17, 22, 21, 5, 789597, tzinfo=datetime.timezone.utc)})"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -286,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +359,7 @@
     "        # Transform parameters using the transformer client\n",
     "        # If switching to using the proxy, you would remove this line\n",
     "        # and let the proxy handle the parameter transformation instead.\n",
-    "        model_params = await self.param_transformer.get_params(model_id, params)\n",
+    "        _, model_params = await self.param_transformer.get_params(model_id, params)\n",
     "        pp(model_params)\n",
     "\n",
     "        # Create the appropriate model instance based on provider\n",
@@ -362,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -381,7 +405,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/m_/d_sz9h1577l6qc91t18wm3yh0000gn/T/ipykernel_56981/2742342122.py:50: UserWarning: WARNING! kwargs is not default parameter.\n",
+      "/var/folders/m_/d_sz9h1577l6qc91t18wm3yh0000gn/T/ipykernel_78277/791531292.py:50: UserWarning: WARNING! kwargs is not default parameter.\n",
       "                kwargs was transferred to model_kwargs.\n",
       "                Please confirm that kwargs is what you intended.\n",
       "  model = init_chat_model(\n"
@@ -390,10 +414,10 @@
     {
      "data": {
       "text/plain": [
-       "ChatOpenAI(client=<openai.resources.chat.completions.completions.Completions object at 0x11cafac10>, async_client=<openai.resources.chat.completions.completions.AsyncCompletions object at 0x11cafafd0>, root_client=<openai.OpenAI object at 0x11caf9090>, root_async_client=<openai.AsyncOpenAI object at 0x11cafad50>, model_name='gpt-4.1', model_kwargs={'kwargs': {'streaming': True, 'verbose': True, 'temperature': 0.7, 'api_key': SecretStr('**********'), 'base_url': 'https://api.openai.com/v1', 'model': 'gpt-4.1'}}, openai_api_key=SecretStr('**********'))"
+       "ChatOpenAI(client=<openai.resources.chat.completions.completions.Completions object at 0x12c897610>, async_client=<openai.resources.chat.completions.completions.AsyncCompletions object at 0x12c8979d0>, root_client=<openai.OpenAI object at 0x12c897390>, root_async_client=<openai.AsyncOpenAI object at 0x12c897750>, model_name='gpt-4.1', model_kwargs={'kwargs': {'streaming': True, 'verbose': True, 'temperature': 0.7, 'api_key': SecretStr('**********'), 'base_url': 'https://api.openai.com/v1', 'model': 'gpt-4.1'}}, openai_api_key=SecretStr('**********'))"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -404,6 +428,13 @@
     "model, model_info = await model_factory.create_model(model_id, {\"temperature\": 0.7})\n",
     "model"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/registry_example.ipynb
+++ b/examples/registry_example.ipynb
@@ -33,9 +33,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m2025-06-17 23:25:50\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mcreating_model_registry_singleton\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:50\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_model_data             \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m62\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:50\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:50\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_model_registry_singleton\u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36menv_file_exists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36menv_file_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36mmodels_data_path\u001b[0m=\u001b[35m/Users/someuser/langgate/packages/registry/src/langgate/registry/data/default_models.json\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:50\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_base_local_registry_client\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:50\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_registry_client_singleton\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "from langgate.registry import LocalRegistryClient\n",
     "\n",
@@ -53,15 +66,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2m2025-06-10 23:30:57\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
-      "\u001b[2m2025-06-10 23:30:57\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:57\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshing_model_cache        \u001b[0m\n",
+      "\u001b[2m2025-06-17 23:25:57\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mrefreshed_model_cache         \u001b[0m \u001b[36mmodel_count\u001b[0m=\u001b[35m5\u001b[0m\n",
       "Available models: 5\n",
       "- openai/gpt-4.1: GPT-4.1\n",
       "- openai/o3: o3\n",
@@ -88,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +129,8 @@
       " 'id': 'openai/gpt-4.1',\n",
       " 'name': 'GPT-4.1',\n",
       " 'provider': {'id': 'openai', 'name': 'OpenAI'},\n",
-      " 'updated_dt': datetime.datetime(2025, 6, 10, 22, 30, 52, 228897, tzinfo=datetime.timezone.utc)}\n"
+      " 'provider_id': 'openai',\n",
+      " 'updated_dt': datetime.datetime(2025, 6, 17, 22, 25, 50, 54626, tzinfo=datetime.timezone.utc)}\n"
      ]
     }
    ],
@@ -142,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -166,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -200,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {

--- a/examples/transformer_example.ipynb
+++ b/examples/transformer_example.ipynb
@@ -32,9 +32,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m2025-06-17 23:26:22\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_config_path          \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:26:22\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mresolved_env_file_path        \u001b[0m \u001b[36mexists\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mpath\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/.env\u001b[0m \u001b[36msource\u001b[0m=\u001b[35mdefault\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:26:22\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mloaded_config                 \u001b[0m \u001b[36mconfig_path\u001b[0m=\u001b[35m/Users/someuser/langgate/examples/langgate_config.yaml\u001b[0m\n",
+      "\u001b[2m2025-06-17 23:26:22\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1minitialized_local_transformer_client\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "from langgate.transform import LocalTransformerClient\n",
     "\n",
@@ -53,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -87,12 +98,13 @@
       "{'max_tokens': 1000, 'stream': True, 'temperature': 0.7}\n",
       "\n",
       "Transformed parameters:\n",
-      "{'api_key': SecretStr('**********'),\n",
-      " 'base_url': 'https://api.anthropic.com',\n",
-      " 'max_tokens': 1000,\n",
-      " 'model': 'claude-sonnet-4',\n",
-      " 'stream': True,\n",
-      " 'temperature': 0.7}\n"
+      "('anthropic',\n",
+      " {'api_key': SecretStr('**********'),\n",
+      "  'base_url': 'https://api.anthropic.com',\n",
+      "  'max_tokens': 1000,\n",
+      "  'model': 'claude-sonnet-4-0',\n",
+      "  'stream': True,\n",
+      "  'temperature': 0.7})\n"
      ]
     }
    ],
@@ -121,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -132,12 +144,13 @@
       "{'max_tokens': 1000, 'stream': True, 'temperature': 0.7}\n",
       "\n",
       "Transformed parameters:\n",
-      "{'api_key': SecretStr('**********'),\n",
-      " 'base_url': 'https://api.anthropic.com',\n",
-      " 'max_tokens': 1000,\n",
-      " 'model': 'claude-sonnet-4',\n",
-      " 'stream': True,\n",
-      " 'thinking': {'budget_tokens': 1024, 'type': 'enabled'}}\n"
+      "('anthropic',\n",
+      " {'api_key': SecretStr('**********'),\n",
+      "  'base_url': 'https://api.anthropic.com',\n",
+      "  'max_tokens': 1000,\n",
+      "  'model': 'claude-sonnet-4-0',\n",
+      "  'stream': True,\n",
+      "  'thinking': {'budget_tokens': 1024, 'type': 'enabled'}})\n"
      ]
     }
    ],

--- a/packages/core/src/langgate/core/data/default_config.yaml
+++ b/packages/core/src/langgate/core/data/default_config.yaml
@@ -40,16 +40,19 @@ services:
   xai:
     api_key: "${XAI_API_KEY}"
     base_url: "https://api.x.ai/v1"
+    api_format: openai
 
   fireworks_ai:
     api_key: "${FIREWORKS_API_KEY}"
     base_url: "https://api.fireworks.ai/inference/v1"
+    api_format: openai
     default_params:
       tiktoken_model_name: gpt-4o
 
   openrouter:
     api_key: "${OPENROUTER_API_KEY}"
     base_url: "https://api.openrouter.ai/v1"
+    api_format: openai
     default_params:
       tiktoken_model_name: gpt-4o
       # extra_headers:
@@ -59,6 +62,7 @@ services:
   eleutheria/vllm:
     api_key: "${ELEUTHERIA_VLLM_API_KEY}"
     base_url: "${ELEUTHERIA_VLLM_BASE_URL}"
+    api_format: openai
     tiktoken_model_name: gpt-4o
 
 

--- a/packages/core/src/langgate/core/data/default_config.yaml
+++ b/packages/core/src/langgate/core/data/default_config.yaml
@@ -29,29 +29,38 @@ services:
         remove_params:
           - temperature
 
+  gemini:
+    api_key: "${GEMINI_API_KEY}"
+    # TODO add vertex service provider
+
+  mistralai:
+    api_key: "${MISTRAL_API_KEY}"
+    base_url: "https://api.mistral.ai/v1"
+
+  xai:
+    api_key: "${XAI_API_KEY}"
+    base_url: "https://api.x.ai/v1"
+
   fireworks_ai:
     api_key: "${FIREWORKS_API_KEY}"
     base_url: "https://api.fireworks.ai/inference/v1"
     default_params:
       tiktoken_model_name: gpt-4o
 
-  gemini:
-    api_key: "${GEMINI_API_KEY}"
-    # TODO use vertex
-    # base_url: "${GEMINI_BASE_URL}"
+  openrouter:
+    api_key: "${OPENROUTER_API_KEY}"
+    base_url: "https://api.openrouter.ai/v1"
+    default_params:
+      tiktoken_model_name: gpt-4o
+      # extra_headers:
+      #   "HTTP-Referer": "<YOUR_SITE_URL>"
+      #   "X-Title": "<YOUR_SITE_NAME>"
 
   eleutheria/vllm:
     api_key: "${ELEUTHERIA_VLLM_API_KEY}"
     base_url: "${ELEUTHERIA_VLLM_BASE_URL}"
     tiktoken_model_name: gpt-4o
 
-  xai:
-    api_key: "${XAI_API_KEY}"
-    base_url: "https://api.x.ai/v1"
-
-  mistralai:
-    api_key: "${MISTRAL_API_KEY}"
-    base_url: "https://api.mistral.ai/v1"
 
 # Model-specific configurations
 models:
@@ -289,8 +298,8 @@ models:
 
   - id: google/gemma-3-27b-it
     service:
-      provider: gemini
-      model_id: gemma-3-27b-it
+      provider: openrouter
+      model_id: google/gemma-3-27b-it:free
 
   - id: mistralai/magistral-medium-latest
     service:

--- a/packages/core/src/langgate/core/data/default_config.yaml
+++ b/packages/core/src/langgate/core/data/default_config.yaml
@@ -243,11 +243,6 @@ models:
       provider: fireworks_ai
       model_id: accounts/fireworks/models/llama-v3p3-70b-instruct
 
-  - id: meta/llama-3.2-90b-vision
-    service:
-      provider: fireworks_ai
-      model_id: accounts/fireworks/models/llama-v3p2-90b-vision-instruct
-
   - id: meta/llama-3.1-405b
     service:
       provider: fireworks_ai
@@ -258,25 +253,43 @@ models:
       provider: fireworks_ai
       model_id: accounts/fireworks/models/llama-v3p1-8b-instruct
 
-  - id: meta/llama-3.2-3b
-    service:
-      provider: fireworks_ai
-      model_id: accounts/fireworks/models/llama-v3p2-3b-instruct
-
   - id: google/gemini-2.5-pro
     service:
       provider: gemini
-      model_id: gemini-2.5-pro-preview
+      model_id: gemini-2.5-pro
+    override_params:
+      thinking_budget: -1
+      include_thoughts: true
 
   - id: google/gemini-2.5-flash
     service:
       provider: gemini
-      model_id: gemini-2.5-flash-preview
+      model_id: gemini-2.5-flash
 
   - id: google/gemini-2.5-flash-thinking
     service:
       provider: gemini
-      model_id: gemini-2.5-flash-preview-05-20:thinking
+      model_id: gemini-2.5-flash
+    name: Gemini 2.5 Flash Think
+    description: "Gemini 2.5 Flash Thinking from Google is a variant of Gemini 2.5 Flash with thinking mode enabled, allowing it to show its reasoning process for improved performance and explainability."
+    override_params:
+      thinking_budget: -1
+      include_thoughts: true
+
+  - id: google/gemini-2.5-flash-lite
+    service:
+      provider: gemini
+      model_id: gemini-2.5-flash-lite-preview-06-17
+
+  - id: google/gemini-2.5-flash-lite-thinking
+    service:
+      provider: gemini
+      model_id: gemini-2.5-flash-lite-preview-06-17
+    name: Gemini 2.5 Flash Lite Think
+    description: "Gemini 2.5 Flash Lite Thinking is a variant of Gemini 2.5 Flash Lite with thinking mode enabled, allowing it to show its reasoning process for improved performance and explainability."
+    override_params:
+      thinking_budget: -1
+      include_thoughts: true
 
   - id: google/gemini-2.0-flash
     service:

--- a/packages/core/src/langgate/core/data/default_config.yaml
+++ b/packages/core/src/langgate/core/data/default_config.yaml
@@ -31,7 +31,10 @@ services:
 
   gemini:
     api_key: "${GEMINI_API_KEY}"
-    # TODO add vertex service provider
+    # you can use this `api_format` key in your client class lookup to map to a
+    # google-genai client class for both Gemini API and Vertex AI services
+    api_format: google
+    # TODO add vertex service provider example
 
   mistralai:
     api_key: "${MISTRAL_API_KEY}"
@@ -348,7 +351,7 @@ models:
   - id: mistralai/mistral-nemo
     service:
       provider: mistralai
-      model_id: mistral-nemo
+      model_id: open-mistral-nemo
 
   - id: alibaba/qwen3-235b-a22b
     service:

--- a/packages/core/src/langgate/core/schemas/config.py
+++ b/packages/core/src/langgate/core/schemas/config.py
@@ -28,6 +28,7 @@ class ServiceConfig(BaseModel):
 
     api_key: str | SecretStr
     base_url: UrlOrEnvVar | None = None
+    api_format: str | None = None
     default_params: dict[str, Any] = Field(default_factory=dict)
     override_params: dict[str, Any] = Field(default_factory=dict)
     remove_params: list[str] = Field(default_factory=list)
@@ -61,6 +62,7 @@ class ModelConfig(BaseModel):
     service: ModelServiceConfig
     name: str | None = None
     description: str | None = None
+    api_format: str | None = None
     default_params: dict[str, Any] = Field(default_factory=dict)
     override_params: dict[str, Any] = Field(default_factory=dict)
     remove_params: list[str] = Field(default_factory=list)

--- a/packages/processor/src/langgate/processor/ext_proc.py
+++ b/packages/processor/src/langgate/processor/ext_proc.py
@@ -116,7 +116,7 @@ class LangGateExtProc(BaseExtProcService):
                     request["original_model"] = original_model
 
                     # Transform parameters using our transformer
-                    transformed_params = await self.transformer.get_params(
+                    _, transformed_params = await self.transformer.get_params(
                         original_model, json_body
                     )
 

--- a/packages/registry/src/langgate/registry/data/default_models.json
+++ b/packages/registry/src/langgate/registry/data/default_models.json
@@ -1325,7 +1325,35 @@
     "model_provider": "google",
     "model_provider_name": "Google",
     "capabilities": {
-      "supports_tools": true,
+      "supports_tools": false,
+      "supports_vision": true,
+      "supports_response_schema": true,
+      "supports_system_messages": true,
+      "supports_tool_choice": true
+    },
+    "context": {
+      "max_input_tokens": 131072,
+      "max_output_tokens": 16384
+    },
+    "costs": {
+      "input_cost_per_token": "1E-7",
+      "output_cost_per_token": "2E-7",
+      "input_cost_per_image": "0.0000256"
+    },
+    "description": "Gemma 3 is an open-source model family from Google that supports multimodal inputs with a 128k token context window and comes in four sizes (1B, 4B, 12B, and 27B parameters). It excels at math, reasoning, coding, and multilingual tasks across 140+ languages.",
+    "openrouter_model_id": "google/gemma-3-27b-it",
+    "_last_updated": "2025-06-16T16:54:22.642115+00:00",
+    "_data_source": "openrouter",
+    "_last_updated_from_id": "google/gemma-3-27b-it"
+  },
+    "openrouter/google/gemma-3-27b-it:free": {
+    "name": "Gemma 3 27B",
+    "mode": "chat",
+    "service_provider": "google",
+    "model_provider": "google",
+    "model_provider_name": "Google",
+    "capabilities": {
+      "supports_tools": false,
       "supports_vision": true,
       "supports_response_schema": true,
       "supports_system_messages": true,

--- a/packages/registry/src/langgate/registry/data/default_models.json
+++ b/packages/registry/src/langgate/registry/data/default_models.json
@@ -821,6 +821,7 @@
     "model_provider_name": "Meta",
     "capabilities": {
       "supports_vision": true,
+      "supports_tools": true,
       "supports_tool_choice": true
     },
     "context": {
@@ -842,6 +843,7 @@
     "model_provider_name": "Meta",
     "capabilities": {
       "supports_vision": true,
+      "supports_tools": true,
       "supports_tool_choice": true
     },
     "context": {
@@ -1727,7 +1729,7 @@
     "description": "Open Mixtral 8x22B is a mixture-of-experts model with 22B active parameters out of 141B total.",
     "source": "https://mistral.ai/pricing#api-pricing"
   },
-  "mistralai/mistral-nemo": {
+  "mistralai/open-mistral-nemo": {
     "name": "Mistral Nemo",
     "mode": "chat",
     "service_provider": "mistralai",

--- a/packages/registry/src/langgate/registry/data/default_models.json
+++ b/packages/registry/src/langgate/registry/data/default_models.json
@@ -731,26 +731,6 @@
     "description": "Llama 3.3 70B by Meta is an instruction tuned text only model, optimized for multilingual dialogue use cases. It improves upon Llama 3.1 70B with advances in tool calling, multilingual text support, math and coding. The model achieves stellar results in reasoning, math and instructions, providing similar performance as 3.1 405B but with significant speed and cost improvements.",
     "source": "https://fireworks.ai/pricing"
   },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
-    "name": "Llama 3.2 90B Vision",
-    "mode": "chat",
-    "service_provider": "fireworks_ai",
-    "model_provider": "meta",
-    "model_provider_name": "Meta",
-    "capabilities": {
-      "supports_vision": true
-    },
-    "context": {
-      "max_input_tokens": 128000,
-      "max_output_tokens": 16384
-    },
-    "costs": {
-      "input_cost_per_token": "9E-7",
-      "output_cost_per_token": "9E-7"
-    },
-    "description": "The Llama 3.2, 90 billion parameter multi-modal model by Meta is able to reason on high resolution images. Optimized for visual recognition, image reasoning, captioning, and answering general questions about an image, the model can understand visual data, such as charts and graphs and also bridge the gap between vision and language by generating text to describe images details.",
-    "source": "https://fireworks.ai/pricing"
-  },
   "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct": {
     "name": "Llama 3.1 405B",
     "mode": "chat",
@@ -793,26 +773,6 @@
     "description": "The Meta Llama 3.1 collection of multilingual models are pretrained and instruction tuned generative models in 8B, 70B and 405B sizes, optimized for multilingual dialogue use cases. The 8B model is the smallest of the family and most cost effective for basic instruction following tasks.",
     "source": "https://fireworks.ai/pricing"
   },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p2-3b-instruct": {
-    "name": "Llama 3.2 3B",
-    "mode": "chat",
-    "service_provider": "fireworks_ai",
-    "model_provider": "meta",
-    "model_provider_name": "Meta",
-    "capabilities": {
-      "supports_tools": false
-    },
-    "context": {
-      "max_input_tokens": 128000,
-      "max_output_tokens": 16384
-    },
-    "costs": {
-      "input_cost_per_token": "0.0000001",
-      "output_cost_per_token": "0.0000001"
-    },
-    "description": "Llama 3.2 3B instruct is a lightweight, multilingual model from Meta. The model is designed for efficiency and offers substantial latency and cost improvements compared to larger models. Example use cases for the model include query and prompt rewriting and writing assistance.",
-    "source": "https://fireworks.ai/pricing"
-  },
   "fireworks_ai/accounts/fireworks/models/llama4-maverick-instruct-basic": {
     "name": "Llama 4 Maverick",
     "mode": "chat",
@@ -832,7 +792,7 @@
       "input_cost_per_token": "0.00000022",
       "output_cost_per_token": "0.00000088"
     },
-    "description": "The Llama 4 collection of models are natively multimodal AI models that enable text and multimodal experiences. These models leverage a mixture-of-experts architecture to offer industry-leading performance in text and image understanding.",
+    "description": "The Llama 4 collection of models are natively multimodal AI models. Llama 4 Maverick is a general purpose LLM containing 17 billion active parameters, 128 experts, and 400 billion total parameters, offering high quality at a lower price compared to Llama 3.3 70B.",
     "source": "https://fireworks.ai/pricing#serverless-pricing"
   },
   "fireworks_ai/accounts/fireworks/models/llama4-scout-instruct-basic": {
@@ -854,7 +814,7 @@
       "input_cost_per_token": "0.00000015",
       "output_cost_per_token": "0.0000006"
     },
-    "description": "The Llama 4 collection of models are natively multimodal AI models that enable text and multimodal experiences. These models leverage a mixture-of-experts architecture to offer industry-leading performance in text and image understanding.",
+    "description": "The Llama 4 collection of models are natively multimodal AI models. Llama 4 Scout is smaller than Maverick, with 17B active parameters, 16 experts and 109B total parameters. Its low cost, large context window, and multimodal understanding make it ideal for processing large amounts of data, such as documents, code, and images.",
     "source": "https://fireworks.ai/pricing#serverless-pricing"
   },
   "fireworks_ai/accounts/fireworks/models/qwen2p5-72b-instruct": {
@@ -1193,7 +1153,7 @@
     "source": "https://ai.google.dev/pricing",
     "tpm": 4000000
   },
-  "gemini/gemini-2.5-pro-preview": {
+  "gemini/gemini-2.5-pro": {
     "name": "Gemini 2.5 Pro",
     "mode": "chat",
     "service_provider": "gemini",
@@ -1217,10 +1177,10 @@
       "input_cost_per_image": "0.00516"
     },
     "description": "Gemini 2.5 Pro is Google's state-of-the-art thinking model, capable of reasoning over complex problems in code, math, and STEM, as well as analyzing large datasets, codebases, and documents using long context.",
-    "openrouter_model_id": "google/gemini-2.5-pro-preview",
+    "openrouter_model_id": "google/gemini-2.5-pro",
     "_last_updated": "2025-06-16T16:54:22.641478+00:00",
     "_data_source": "openrouter",
-    "_last_updated_from_id": "google/gemini-2.5-pro-preview"
+    "_last_updated_from_id": "google/gemini-2.5-pro"
   },
   "gemini/gemini-2.5-pro-preview-06-05": {
     "name": "Gemini 2.5 Pro 0605",
@@ -1251,7 +1211,7 @@
     "_data_source": "openrouter",
     "_last_updated_from_id": "google/gemini-2.5-pro-preview-05-06"
   },
-  "gemini/gemini-2.5-flash-preview": {
+  "gemini/gemini-2.5-flash": {
     "name": "Gemini 2.5 Flash",
     "mode": "chat",
     "service_provider": "gemini",
@@ -1286,39 +1246,45 @@
       "input_cost_per_image": "0.0006192"
     },
     "description": "Gemini 2.5 Flash is a versatile multimodal model with a 1 million token context window, designed for diverse tasks.",
-    "openrouter_model_id": "google/gemini-2.5-flash-preview",
+    "openrouter_model_id": "google/gemini-2.5-flash",
     "_last_updated": "2025-06-16T16:54:22.641672+00:00",
     "_data_source": "openrouter",
-    "_last_updated_from_id": "google/gemini-2.5-flash-preview"
+    "_last_updated_from_id": "google/gemini-2.5-flash"
   },
-  "gemini/gemini-2.5-flash-preview-05-20:thinking": {
-    "name": "Gemini 2.5 Flash Thinking",
+  "gemini/gemini-2.5-flash-lite-preview-06-17": {
+        "name": "Gemini 2.5 Flash Lite",
     "mode": "chat",
     "service_provider": "gemini",
     "model_provider": "google",
     "model_provider_name": "Google",
+    "modalities": {
+      "input": [
+        "file",
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
     "capabilities": {
       "supports_tools": true,
       "supports_vision": true,
       "supports_response_schema": true,
       "supports_system_messages": true,
-      "supports_tool_choice": true
+      "supports_tool_choice": true,
+      "supports_reasoning": true
     },
     "context": {
       "max_input_tokens": 1048576,
       "max_output_tokens": 65535
     },
     "costs": {
-      "input_cost_per_token": "1.5E-7",
-      "output_cost_per_token": "0.0000035",
-      "cache_read_input_token_cost": "3.75E-8",
-      "input_cost_per_image": "0.0006192"
+      "input_cost_per_token": "0.0000001",
+      "output_cost_per_token": "0.0000004"
     },
-    "description": "Gemini 2.5 Flash Thinking from Google is capable of showing its thoughts to improve performance and explainability. Combining speed and performance, it excels in coding, science and math, showing its reasoning to solve complex problems.",
-    "openrouter_model_id": "google/gemini-2.5-flash-preview-05-20:thinking",
-    "_last_updated": "2025-06-16T16:54:22.641792+00:00",
-    "_data_source": "openrouter",
-    "_last_updated_from_id": "google/gemini-2.5-flash-preview-05-20:thinking"
+    "description": "Gemini 2.5 Flash-Lite is a lightweight reasoning model in the Gemini 2.5 family, optimized for ultra-low latency and cost efficiency. It offers improved throughput, faster token generation, and better performance compared to earlier Flash models.",
+    "openrouter_model_id": "google/gemini-2.5-flash-lite-preview-06-17"
   },
   "gemini/gemma-3-27b-it": {
     "name": "Gemma 3 27B",

--- a/packages/registry/src/langgate/registry/scripts/update_model_costs.py
+++ b/packages/registry/src/langgate/registry/scripts/update_model_costs.py
@@ -39,6 +39,7 @@ models_data_path = resolve_path(
 # OpenRouter API endpoint
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/models"
 
+# TODO: Add programmatic solution for updating Gemini costs from `curl https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY``
 # TODO: Add programmatic solution for updating Fireworks AI costs from https://fireworks.ai/pricing#serverless-pricing
 # This may require using an LLM to parse the HTML and reason about the data.
 # TODO: Add programmatic solution for updating xAI costs fby querying `https://api.x.ai/v1/language-models`

--- a/packages/sdk/src/langgate/sdk/client.py
+++ b/packages/sdk/src/langgate/sdk/client.py
@@ -66,7 +66,7 @@ class LangGateLocal(LangGateLocalProtocol):
 
     async def get_params(
         self, model_id: str, input_params: dict[str, Any]
-    ) -> dict[str, Any]:
+    ) -> tuple[str, dict[str, Any]]:
         """Transform parameters for the specified model.
 
         Args:
@@ -74,7 +74,7 @@ class LangGateLocal(LangGateLocalProtocol):
             input_params: The parameters to transform
 
         Returns:
-            The transformed parameters
+            A tuple containing (api_format, transformed_parameters)
 
         Raises:
             ValueError: If the model is not found

--- a/packages/transform/src/langgate/transform/protocol.py
+++ b/packages/transform/src/langgate/transform/protocol.py
@@ -12,7 +12,7 @@ class TransformerClientProtocol(Protocol):
 
     async def get_params(
         self, model_id: str, input_params: dict[str, Any]
-    ) -> dict[str, Any]:
+    ) -> tuple[str, dict[str, Any]]:
         """Get transformed parameters for the specified model.
 
         Args:
@@ -20,6 +20,6 @@ class TransformerClientProtocol(Protocol):
             input_params: The parameters to transform
 
         Returns:
-            The transformed parameters
+            A tuple containing (api_format, transformed_parameters)
         """
         ...

--- a/tests/fixtures/registry_fixtures.py
+++ b/tests/fixtures/registry_fixtures.py
@@ -124,6 +124,34 @@ def mock_config_yaml(tmp_path: Path) -> Generator[Path]:
                     }
                 },
             },
+            "openrouter": {
+                "api_key": "${OPENROUTER_API_KEY}",
+                "base_url": "https://api.openrouter.ai/v1",
+                "api_format": "openai",
+                "default_params": {
+                    "tiktoken_model_name": "gpt-4o",
+                },
+            },
+            "xai": {
+                "api_key": "${XAI_API_KEY}",
+                "base_url": "https://api.x.ai/v1",
+                "api_format": "openai",
+            },
+            "fireworks_ai": {
+                "api_key": "${FIREWORKS_API_KEY}",
+                "base_url": "https://api.fireworks.ai/inference/v1",
+                "api_format": "openai",
+                "default_params": {
+                    "tiktoken_model_name": "gpt-4o",
+                },
+            },
+            "gemini": {
+                "api_key": "${GEMINI_API_KEY}",
+            },
+            "mistralai": {
+                "api_key": "${MISTRAL_API_KEY}",
+                "base_url": "https://api.mistral.ai/v1",
+            },
         },
         "models": [
             {
@@ -160,6 +188,41 @@ def mock_config_yaml(tmp_path: Path) -> Generator[Path]:
                     }
                 },
             },
+            {
+                "id": "google/gemma-3-27b-it",
+                "service": {
+                    "provider": "openrouter",
+                    "model_id": "google/gemma-3-27b-it:free",
+                },
+            },
+            {
+                "id": "xai/grok-3",
+                "service": {
+                    "provider": "xai",
+                    "model_id": "grok-3-latest",
+                },
+            },
+            {
+                "id": "deepseek/deepseek-r1",
+                "service": {
+                    "provider": "fireworks_ai",
+                    "model_id": "accounts/fireworks/models/deepseek-r1",
+                },
+            },
+            {
+                "id": "google/gemini-2.5-pro",
+                "service": {
+                    "provider": "gemini",
+                    "model_id": "gemini-2.5-pro-preview",
+                },
+            },
+            {
+                "id": "mistralai/magistral-medium-latest",
+                "service": {
+                    "provider": "mistralai",
+                    "model_id": "magistral-medium-latest",
+                },
+            },
         ],
     }
     config_yaml_path = tmp_path / "langgate_config.yaml"
@@ -176,6 +239,11 @@ def mock_env_file(tmp_path: Path) -> Generator[Path]:
     with open(env_path, "w") as f:
         f.write("OPENAI_API_KEY=sk-test-123\n")
         f.write("ANTHROPIC_API_KEY=sk-ant-test-123\n")
+        f.write("OPENROUTER_API_KEY=sk-or-test-123\n")
+        f.write("XAI_API_KEY=xai-test-123\n")
+        f.write("FIREWORKS_API_KEY=fw-test-123\n")
+        f.write("GEMINI_API_KEY=gm-test-123\n")
+        f.write("MISTRAL_API_KEY=ms-test-123\n")
         f.write("SECRET_KEY=test-secret-key\n")
 
     yield env_path

--- a/tests/integration_tests/transform/test_transformer_client.py
+++ b/tests/integration_tests/transform/test_transformer_client.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 from pydantic.types import SecretStr
 
+from langgate.core.schemas.config import ConfigSchema
 from langgate.transform.local import LocalTransformerClient
 from tests.utils.config_utils import config_path_resolver, patch_load_yaml_config
 
@@ -286,3 +287,156 @@ async def test_transformer_without_env_file():
             ValueError, match=f"Model '{model_id}' not found in configuration"
         ):
             await client.get_params(model_id, {})
+
+
+# API Format Mapping Tests
+
+
+@pytest.mark.asyncio
+async def test_api_format_service_level_openai_providers(
+    local_transformer_client: LocalTransformerClient,
+):
+    """Test API format resolution for OpenAI-compatible service providers."""
+    # Test OpenRouter (uses OpenAI API format)
+    api_format, _ = await local_transformer_client.get_params(
+        "google/gemma-3-27b-it", {}
+    )
+    assert api_format == "openai"
+
+    # Test xAI (uses OpenAI API format)
+    api_format, _ = await local_transformer_client.get_params("xai/grok-3", {})
+    assert api_format == "openai"
+
+    # Test Fireworks AI (uses OpenAI API format)
+    api_format, _ = await local_transformer_client.get_params(
+        "deepseek/deepseek-r1", {}
+    )
+    assert api_format == "openai"
+
+
+@pytest.mark.asyncio
+async def test_api_format_fallback_to_provider_name(
+    local_transformer_client: LocalTransformerClient,
+):
+    """Test API format fallback to provider name when no api_format specified."""
+    # OpenAI provider (no explicit api_format, should fallback to 'openai')
+    api_format, _ = await local_transformer_client.get_params("gpt-4o", {})
+    assert api_format == "openai"
+
+    # Anthropic provider (no explicit api_format, should fallback to 'anthropic')
+    api_format, _ = await local_transformer_client.get_params(
+        "anthropic/claude-sonnet-4", {}
+    )
+    assert api_format == "anthropic"
+
+    # Gemini provider (no explicit api_format, should fallback to 'gemini')
+    api_format, _ = await local_transformer_client.get_params(
+        "google/gemini-2.5-pro", {}
+    )
+    assert api_format == "gemini"
+
+    # MistralAI provider (no explicit api_format, should fallback to 'mistralai')
+    api_format, _ = await local_transformer_client.get_params(
+        "mistralai/magistral-medium-latest", {}
+    )
+    assert api_format == "mistralai"
+
+
+@pytest.mark.asyncio
+async def test_api_format_precedence_hierarchy():
+    """Test API format precedence: model.api_format → service.api_format → service.provider."""
+    # Reset singleton to test with custom configuration
+    LocalTransformerClient._instance = None
+
+    # Custom configuration to test precedence
+    custom_config = {
+        "default_params": {"temperature": 0.7},
+        "services": {
+            "custom_service": {
+                "api_key": "${CUSTOM_API_KEY}",
+                "base_url": "https://api.custom.com/v1",
+                "api_format": "service_format",  # Service-level API format
+                "default_params": {},
+            }
+        },
+        "models": [
+            {
+                "id": "test/model-with-override",
+                "service": {"provider": "custom_service", "model_id": "actual-model"},
+                "api_format": "model_override",  # Model-level override (highest precedence)
+                "default_params": {},
+                "override_params": {},
+                "remove_params": [],
+                "rename_params": {},
+            },
+            {
+                "id": "test/model-without-override",
+                "service": {"provider": "custom_service", "model_id": "another-model"},
+                # No model-level api_format, should use service-level
+                "default_params": {},
+                "override_params": {},
+                "remove_params": [],
+                "rename_params": {},
+            },
+        ],
+        "app_config": {},
+    }
+
+    with (
+        mock.patch.dict(os.environ, {"CUSTOM_API_KEY": "test-key"}),
+        patch_load_yaml_config(ConfigSchema.model_validate(custom_config)),
+    ):
+        client = LocalTransformerClient()
+
+        # Test model-level override (highest precedence)
+        api_format, _ = await client.get_params("test/model-with-override", {})
+        assert api_format == "model_override"
+
+        # Test service-level fallback (when no model-level override)
+        api_format, _ = await client.get_params("test/model-without-override", {})
+        assert api_format == "service_format"
+
+
+@pytest.mark.asyncio
+async def test_api_format_provider_name_fallback():
+    """Test fallback to provider name when no api_format is specified at any level."""
+    # Reset singleton to test with custom configuration
+    LocalTransformerClient._instance = None
+
+    # Custom configuration with no api_format specified
+    custom_config = {
+        "default_params": {"temperature": 0.7},
+        "services": {
+            "fallback_provider": {
+                "api_key": "${FALLBACK_API_KEY}",
+                "base_url": "https://api.fallback.com/v1",
+                # No api_format specified at service level
+                "default_params": {},
+            }
+        },
+        "models": [
+            {
+                "id": "test/fallback-model",
+                "service": {
+                    "provider": "fallback_provider",
+                    "model_id": "fallback-model",
+                },
+                # No api_format specified at model level
+                "default_params": {},
+                "override_params": {},
+                "remove_params": [],
+                "rename_params": {},
+            },
+        ],
+        "app_config": {},
+    }
+
+    with (
+        mock.patch.dict(os.environ, {"FALLBACK_API_KEY": "test-key"}),
+        patch_load_yaml_config(ConfigSchema.model_validate(custom_config)),
+    ):
+        client = LocalTransformerClient()
+
+        # Should fallback to provider name
+        api_format, _ = await client.get_params("test/fallback-model", {})
+        assert api_format == "fallback_provider"

--- a/tests/integration_tests/transform/test_transformer_client.py
+++ b/tests/integration_tests/transform/test_transformer_client.py
@@ -89,7 +89,7 @@ async def test_transformer_global_defaults(
 ):
     """Test applying global default parameters."""
     # Test with empty params
-    result = await local_transformer_client.get_params("gpt-4o", {})
+    _, result = await local_transformer_client.get_params("gpt-4o", {})
 
     # Global default should be applied
     assert result["temperature"] == 0.7
@@ -101,11 +101,13 @@ async def test_transformer_service_provider_defaults(
 ):
     """Test applying service provider default parameters."""
     # OpenAI service provider defaults
-    result = await local_transformer_client.get_params("gpt-4o", {})
+    _, result = await local_transformer_client.get_params("gpt-4o", {})
     assert result["max_tokens"] == 1000
 
     # Anthropic service provider defaults
-    result = await local_transformer_client.get_params("anthropic/claude-sonnet-4", {})
+    _, result = await local_transformer_client.get_params(
+        "anthropic/claude-sonnet-4", {}
+    )
     assert result["max_tokens"] == 2000
 
 
@@ -115,7 +117,7 @@ async def test_transformer_model_pattern_params(
 ):
     """Test applying model pattern specific parameters."""
     # Anthropic reasoning pattern
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4-reasoning", {}
     )
 
@@ -133,7 +135,7 @@ async def test_transformer_model_pattern_defaults(
 ):
     """Test applying default parameters at the model pattern level."""
     # Use empty params to ensure defaults are applied
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4-reasoning", {}
     )
 
@@ -142,7 +144,7 @@ async def test_transformer_model_pattern_defaults(
 
     # User params should still override pattern defaults
     user_params = {"max_tokens": 1000}
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4-reasoning", user_params
     )
     assert result["max_tokens"] == 1000
@@ -155,7 +157,7 @@ async def test_transformer_model_pattern_renames(
     """Test parameter renaming at the model pattern level."""
     # Anthropic reasoning pattern has reasoning -> thinking rename
     user_params = {"reasoning": {"depth": "deep"}, "temperature": 0.7}
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4-reasoning", user_params
     )
 
@@ -173,7 +175,7 @@ async def test_transformer_model_specific_overrides(
 ):
     """Test applying model-specific override parameters."""
     # Model with specific thinking override
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4-reasoning", {}
     )
 
@@ -187,7 +189,7 @@ async def test_transformer_user_params_precedence(
 ):
     """Test that user parameters have precedence over defaults."""
     # User params should override defaults
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "gpt-4o", {"temperature": 0.5, "max_tokens": 500}
     )
     assert result["temperature"] == 0.5  # User specified
@@ -200,12 +202,14 @@ async def test_transformer_api_key_resolution(
 ):
     """Test that API keys are resolved from environment variables."""
     # OpenAI API key
-    result = await local_transformer_client.get_params("gpt-4o", {})
+    _, result = await local_transformer_client.get_params("gpt-4o", {})
     assert isinstance(result["api_key"], SecretStr)
     assert result["api_key"].get_secret_value() == "sk-test-123"
 
     # Anthropic API key
-    result = await local_transformer_client.get_params("anthropic/claude-sonnet-4", {})
+    _, result = await local_transformer_client.get_params(
+        "anthropic/claude-sonnet-4", {}
+    )
     assert isinstance(result["api_key"], SecretStr)
     assert result["api_key"].get_secret_value() == "sk-ant-test-123"
 
@@ -217,7 +221,7 @@ async def test_transformer_model_specific_renames(
     """Test applying model-specific parameter renaming."""
     # The claude-sonnet-4 model has stop -> stop_sequences rename
     user_params = {"stop": ["END"], "temperature": 0.7}
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4", user_params
     )
 
@@ -238,7 +242,7 @@ async def test_transformer_remove_params(
         "reasoning": {"depth": "deep"},
         "presence_penalty": 0.2,
     }
-    result = await local_transformer_client.get_params(
+    _, result = await local_transformer_client.get_params(
         "anthropic/claude-sonnet-4", user_params
     )
 

--- a/tests/utils/config_utils.py
+++ b/tests/utils/config_utils.py
@@ -10,9 +10,9 @@ from tests.mocks.registry_mocks import create_mock_config
 
 
 @contextmanager
-def patch_load_yaml_config():
+def patch_load_yaml_config(custom_config=None):
     """Patch the load_yaml_config function to return a mock config."""
-    mock_config = create_mock_config()
+    mock_config = custom_config if custom_config else create_mock_config()
     with (
         mock.patch(
             "langgate.transform.local.load_yaml_config",


### PR DESCRIPTION
## Description
<!-- What does this pull request accomplish? -->
- Add an optional `api_format` key to service and model entry schemas to indicate to allow consumers to easily map models to an appropriate API client class.
- For example, some providers like OpenRouter and xAI use the OpenAI-compatible API format rather than their own native API format. Setting `api_format` to `openai` for such a provider or an individual model will return this `api_format` key along with the transformed parameters. This allows consumers of the registry to map models to relevant API clients such as `openai.OpenAI` or `langchain_openai.ChatOpenAI`. 
- Add OpenRouter as a service provider to the default config and use it for Gemma 3. OpenRouter is used for Gemma 3 largely due to a system prompt issue for Gemma when called via `google-genai` - Gemma does not accept a developer/system prompt. Therefore, calling it via the OpenAI format with OpenRouter works better, and Gemma is free, so users opting for the default configuration will not incur any markup assuming they are using it for non-production development whereby rate limiting is acceptable (Alternatively, FireworksAI serves Gemma 3 at a low $0.10 /mtok cost).
- Remove deprecated Llama models.
- Update Gemini models and add Gemini variants with thinking enabled to the default example config.

## Related Pull Requests
<!-- Provide links to any related pull requests. -->

## Relevant Issues
<!-- Does this pull request address any open issues? List them with [closing keywords](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->

## Additional Details
<!-- Add any additional context, screenshots or attachments relevant to the pull request here. -->

## Type of Changes
<!-- Select the category or categories that best describe(s) the nature of changes made in this pull request. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to cease working as expected)

## Checklist
<!-- Use this checklist to ensure that all necessary changes have been made before submitting the pull request. -->
- [x] Documentation updated
- [x] Docstrings/comments added
- [x] Unit/Integration tests added
- [x] Pytest warnings checked in CI logs